### PR TITLE
add hpctoolkit in neurodamus image for CPU profiling

### DIFF
--- a/ami/components/neurodamus-toolchain.yaml
+++ b/ami/components/neurodamus-toolchain.yaml
@@ -197,7 +197,7 @@ phases:
               source neurodamus_venv/bin/activate
               set -euo pipefail
               git clone https://gitlab.com/hpctoolkit/hpctoolkit.git --recursive --depth 1
-              dnf -y install ccache libboost-all-dev
+              dnf -y install ccache boost-devel
               pip install meson
               cd hpctoolkit
               meson setup builddir

--- a/ami/components/neurodamus-toolchain.yaml
+++ b/ami/components/neurodamus-toolchain.yaml
@@ -184,6 +184,28 @@ phases:
               cmake --build neurodamus-models/build
               cmake --install neurodamus-models/build
               echo "End openbraininstitute step: neurodamus"
+      - name: hpctoolkit
+        action: ExecuteBash
+        inputs:
+          commands:
+            - |-
+              #!/bin/bash
+              set -x
+              echo "Start openbraininstitute step: hpctoolkit for CPU profiling"
+              export HOME=/root
+              cd /opt/circuit_simulation
+              source neurodamus_venv/bin/activate
+              set -euo pipefail
+              git clone https://gitlab.com/hpctoolkit/hpctoolkit.git --recursive --depth 1
+              dnf -y install ccache libboost-all-dev
+              pip install meson
+              cd hpctoolkit
+              meson setup builddir
+              cd builddir
+              meson compile
+              meson test
+              meson devenv hpcrun --version
+
   - name: Test
     steps:
       - name: TestNeurodamus

--- a/versions.json
+++ b/versions.json
@@ -2,7 +2,7 @@
     "ami": "obi-parallelcluster-neurodamus-ami-al2023-v3-debug",
     "components": {
         "configure-ami": "1.0.1",
-        "neurodamus-toolchain": "0.0.3-debug",
+        "neurodamus-toolchain": "0.0.3",
         "packages": "1.0.9",
         "singularity-ce": "4.2.2"
     }

--- a/versions.json
+++ b/versions.json
@@ -1,8 +1,8 @@
 {
-    "ami": "obi-parallelcluster-neurodamus-ami-al2023-v2",
+    "ami": "obi-parallelcluster-neurodamus-ami-al2023-v3-debug",
     "components": {
         "configure-ami": "1.0.1",
-        "neurodamus-toolchain": "0.0.2",
+        "neurodamus-toolchain": "0.0.3-debug",
         "packages": "1.0.9",
         "singularity-ce": "4.2.2"
     }


### PR DESCRIPTION
As reported in https://github.com/openbraininstitute/neurodamus/issues/341, this PR adds `hpctoolkit` in the machine image for CPU profiling on AWS.  