### PR TITLE
Use public subnet and temporary SG

### DIFF
--- a/packer/neurodamus.pkr.hcl
+++ b/packer/neurodamus.pkr.hcl
@@ -17,6 +17,9 @@ source "amazon-ebs" "neurodamus" {
   vpc_id        = var.aws_vpc_id
   subnet_id     = var.aws_subnet_id
 
+  associate_public_ip_address = true
+  temporary_security_group_source_cidrs = ["0.0.0.0/0"]
+
   source_ami_filter {
     filters = {
       name                = "al2023-ami-2023.*-x86_64"

--- a/packer/variables.pkr.hcl
+++ b/packer/variables.pkr.hcl
@@ -44,7 +44,7 @@ variable "aws_vpc_id" {
 }
 variable "aws_subnet_id" {
   type    = string
-  default = "subnet-083c5be919895669c" # Bastion host subnet
+  default = "subnet-064de2163c1b2ae2d" # public_a
 }
 
 variable "aws_instance_type" {


### PR DESCRIPTION
The bastion subnet is private and its SG only allows internal VPC traffic via SSM. Switch to public_a subnet, assign a public IP, and let Packer create a temporary SG with SSH access.

for https://github.com/openbraininstitute/prod-circuit-simulation/issues/128