### PR TITLE
Share resulting AMI with production account

### DIFF
--- a/.github/workflows/ami-packer-build.yaml
+++ b/.github/workflows/ami-packer-build.yaml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6

--- a/packer/neurodamus.pkr.hcl
+++ b/packer/neurodamus.pkr.hcl
@@ -17,6 +17,8 @@ source "amazon-ebs" "neurodamus" {
   vpc_id        = var.aws_vpc_id
   subnet_id     = var.aws_subnet_id
 
+  ami_users = var.ami_share_accounts
+
   associate_public_ip_address = true
   temporary_security_group_source_cidrs = ["0.0.0.0/0"]
 

--- a/packer/variables.auto.pkrvars.hcl
+++ b/packer/variables.auto.pkrvars.hcl
@@ -6,6 +6,8 @@ python_version           = "3.12"
 uv_version               = "0.11.15"
 neurodamus_script_commit = "77f9250f8db7f307e518ee7d3da66083c2a6ca71"
 
+ami_share_accounts = ["671250183987"] # production
+
 # the AMI build has to happen on a machine that supports EFA
 aws_instance_type = "c5n.9xlarge"
 

--- a/packer/variables.pkr.hcl
+++ b/packer/variables.pkr.hcl
@@ -33,6 +33,11 @@ variable "neurodamus_commit" {
   description = "Neurodamus git commit or tag to build"
 }
 
+variable "ami_share_accounts" {
+  type        = list(string)
+  description = "list of AWS account IDs to share the resulting AMI with"
+}
+
 variable "aws_region" {
   type    = string
   default = "us-east-1"


### PR DESCRIPTION
from: [Amazon Builder | Integrations | Packer | HashiCorp Developer](https://developer.hashicorp.com/packer/integrations/hashicorp/amazon/latest/components/builder/ebs)
 > ami_users ([]string) - A list of account IDs that have access to launch the resulting AMI(s). By default no additional users other than the user creating the AMI has permissions to launch it.
 
 for https://github.com/openbraininstitute/prod-circuit-simulation/issues/128