### PR TITLE
Bump azure/login action to v3

### DIFF
--- a/.github/workflows/azure-packer-build.yaml
+++ b/.github/workflows/azure-packer-build.yaml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Azure Login
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           # secrets managed by openbraininstitute/azure-terraform-management
           client-id: ${{ secrets.AZURE_CLIENT_ID }}


### PR DESCRIPTION
Fixes CI warning:

```
Annotations 1 warning
build
Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: azure/login@v2. 
For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```